### PR TITLE
chore: Ignore MacOS and Windows in tests

### DIFF
--- a/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CheckReadyAsyncTests.cs
+++ b/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CheckReadyAsyncTests.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Devantler.ContainerEngineProvisioner.Docker.Tests.DockerProvisionerTests;
 
 /// <summary>
@@ -14,6 +16,12 @@ public class CheckReadyAsyncTests
   [Fact]
   public async Task CheckReadyAsync_ReturnsTrue_WhenDockerIsReady()
   {
+    //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    {
+      return;
+    }
+
     // Act
     bool containerEngineIsReady = await _provisioner.CheckReadyAsync(CancellationToken.None);
 

--- a/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateDirectoryInContainerAsyncTests.cs
+++ b/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateDirectoryInContainerAsyncTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Docker.DotNet.Models;
 
 namespace Devantler.ContainerEngineProvisioner.Docker.Tests.DockerProvisionerTests;
@@ -16,6 +17,12 @@ public class CreateDirectoryInContainerAsyncTests
   [Fact]
   public async Task CreateDirectoryInContainerAsync_ValidParameters_CreatesDirectory()
   {
+    //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    {
+      return;
+    }
+
     // Arrange
     await _dockerProvisioner.Client.Images.CreateImageAsync(
       new ImagesCreateParameters

--- a/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateFileInContainerAsyncTests.cs
+++ b/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateFileInContainerAsyncTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Docker.DotNet.Models;
 
 namespace Devantler.ContainerEngineProvisioner.Docker.Tests.DockerProvisionerTests;
@@ -16,6 +17,12 @@ public class CreateFileInContainerAsyncTests
   [Fact]
   public async Task CreateFileInContainerAsync_ValidParameters_CreatesFile()
   {
+    //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    {
+      return;
+    }
+
     // Arrange
     await _dockerProvisioner.Client.Images.CreateImageAsync(
       new ImagesCreateParameters

--- a/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
+++ b/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Devantler.ContainerEngineProvisioner.Docker.Tests.DockerProvisionerTests;
 
 /// <summary>
@@ -14,6 +16,12 @@ public class CreateRegistryAsyncTests
   [Fact]
   public async Task CreateRegistryAsync_RegistryDoesNotExist_CreatesRegistry()
   {
+    //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    {
+      return;
+    }
+
     // Arrange
     string registryName = "new_registry";
     int port = 5999;
@@ -36,6 +44,12 @@ public class CreateRegistryAsyncTests
   [Fact]
   public async Task CreateRegistryAsync_RegistryExists_DoesNotCreateRegistry()
   {
+    //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    {
+      return;
+    }
+
     // Arrange
     string registryName = "new_registry";
     int port = 5999;
@@ -59,6 +73,12 @@ public class CreateRegistryAsyncTests
   [Fact]
   public async Task CreateRegistryAsync_ProxyUrlProvided_CreatesPullThroughRegistry()
   {
+    //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    {
+      return;
+    }
+
     // Arrange
     string registryName = "new_registry";
     int port = 5999;


### PR DESCRIPTION
Exclude tests from running on MacOS and Windows platforms until GitHub Actions supports Docker-in-Docker (dind).