### PR TITLE
feat: add CreateRegistryProxyAsync for docker-registry-proxy support

### DIFF
--- a/src/Devantler.ContainerEngineProvisioner.Core/IContainerEngineProvisioner.cs
+++ b/src/Devantler.ContainerEngineProvisioner.Core/IContainerEngineProvisioner.cs
@@ -1,4 +1,6 @@
-﻿namespace Devantler.ContainerEngineProvisioner.Core;
+﻿using System.Collections.ObjectModel;
+
+namespace Devantler.ContainerEngineProvisioner.Core;
 
 /// <summary>
 /// A container engine provisioner capable of modifying resources in a container engine.
@@ -12,13 +14,22 @@ public interface IContainerEngineProvisioner
   Task<bool> CheckReadyAsync(CancellationToken cancellationToken = default);
 
   /// <summary>
-  /// Creates a registry in the container engine.
+  /// Creates a 'docker.io/registry' in the container engine.
   /// </summary>
   /// <param name="name"></param>
   /// <param name="port"></param>
   /// <param name="proxyUrl"></param>
   /// <param name="cancellationToken"></param>
   Task CreateRegistryAsync(string name, int port, Uri? proxyUrl = default, CancellationToken cancellationToken = default);
+
+  /// <summary>
+  /// Creates a 'rpardini/docker-registry-proxy' in the container engine.
+  /// </summary>
+  /// <param name="name"></param>
+  /// <param name="port"></param>
+  /// <param name="proxyUrls"></param>
+  /// <param name="cancellationToken"></param>
+  Task CreateRegistryProxyAsync(string name, int port, ReadOnlyCollection<Uri> proxyUrls, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Deletes a registry in the container engine.

--- a/src/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
+++ b/src/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
@@ -232,11 +232,11 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
         ["name"] = new Dictionary<string, bool>
         {
           [$"^{name}$"] = true
-      }
+        }
       }
     }, cancellationToken).ConfigureAwait(false) ?? throw new ContainerEngineProvisionerException($"Could not find container '{name}'");
 
-    return containers.FirstOrDefault()?.ID ?? string.Empty;
+    return containers.FirstOrDefault()?.ID ?? throw new ContainerEngineProvisionerException($"Could not find ID for container '{name}'");
   }
 }
 

--- a/src/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
+++ b/src/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
@@ -208,17 +208,17 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
   /// <inheritdoc/>
   public async Task DeleteRegistryAsync(string name, CancellationToken cancellationToken = default)
   {
-    string containerId = await GetContainerIdAsync(name, cancellationToken).ConfigureAwait(false);
-
-    if (string.IsNullOrEmpty(containerId))
+    string containerId;
+    try
     {
-      throw new ContainerEngineProvisionerException($"Could not find registry '{name}'");
+      containerId = await GetContainerIdAsync(name, cancellationToken).ConfigureAwait(false);
     }
-    else
+    catch (ContainerEngineProvisionerException)
     {
-      _ = await Client.Containers.StopContainerAsync(containerId, new ContainerStopParameters(), cancellationToken).ConfigureAwait(false);
-      await Client.Containers.RemoveContainerAsync(containerId, new ContainerRemoveParameters(), cancellationToken).ConfigureAwait(false);
+      return;
     }
+    _ = await Client.Containers.StopContainerAsync(containerId, new ContainerStopParameters(), cancellationToken).ConfigureAwait(false);
+    await Client.Containers.RemoveContainerAsync(containerId, new ContainerRemoveParameters(), cancellationToken).ConfigureAwait(false);
   }
 
   /// <inheritdoc/>

--- a/src/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
+++ b/src/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
@@ -42,7 +42,7 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
       {
         ["name"] = new Dictionary<string, bool>
         {
-          [name] = true
+          [$"^{name}$"] = true
         }
       }
     }, cancellationToken).ConfigureAwait(false);

--- a/src/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
+++ b/src/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
@@ -231,8 +231,8 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
       {
         ["name"] = new Dictionary<string, bool>
         {
-          [name] = true
-        }
+          [$"^{name}$"] = true
+      }
       }
     }, cancellationToken).ConfigureAwait(false) ?? throw new ContainerEngineProvisionerException($"Could not find container '{name}'");
 

--- a/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
+++ b/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
@@ -45,7 +45,7 @@ public class CreateRegistryAsyncTests
   public async Task CreateRegistryAsync_RegistryExists_DoesNotCreateRegistry()
   {
     //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    if ((RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
     {
       return;
     }
@@ -74,7 +74,7 @@ public class CreateRegistryAsyncTests
   public async Task CreateRegistryAsync_ProxyUrlProvided_CreatesPullThroughRegistry()
   {
     //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    if ((RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
     {
       return;
     }

--- a/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
+++ b/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
@@ -17,7 +17,7 @@ public class CreateRegistryAsyncTests
   public async Task CreateRegistryAsync_RegistryDoesNotExist_CreatesRegistry()
   {
     //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    if ((RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
     {
       return;
     }

--- a/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
+++ b/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
@@ -23,7 +23,7 @@ public class CreateRegistryAsyncTests
     }
 
     // Arrange
-    string registryName = "new_registry";
+    string registryName = "registry";
     int port = 5999;
     var cancellationToken = CancellationToken.None;
 
@@ -51,7 +51,7 @@ public class CreateRegistryAsyncTests
     }
 
     // Arrange
-    string registryName = "new_registry";
+    string registryName = "registry";
     int port = 5999;
     var cancellationToken = CancellationToken.None;
 
@@ -80,7 +80,7 @@ public class CreateRegistryAsyncTests
     }
 
     // Arrange
-    string registryName = "new_registry";
+    string registryName = "registry";
     int port = 5999;
     var cancellationToken = CancellationToken.None;
     Uri proxyUrl = new("http://proxy:8080");

--- a/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryProxyAsyncTests.cs
+++ b/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryProxyAsyncTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.ObjectModel;
+using System.Runtime.InteropServices;
+
+namespace Devantler.ContainerEngineProvisioner.Docker.Tests.DockerProvisionerTests;
+
+/// <summary>
+/// Unit tests for <see cref="DockerProvisioner.CreateRegistryProxyAsync(string, int, ReadOnlyCollection{Uri}, CancellationToken)"/> and <see cref="DockerProvisioner.DeleteRegistryAsync(string, CancellationToken)"/>.
+/// </summary>
+public class CreateRegistryProxyAsyncTests
+{
+  readonly DockerProvisioner _provisioner = new();
+
+  /// <summary>
+  /// Tests whether the registry is created when it does not exist.
+  /// </summary>
+  /// <returns></returns>
+  [Fact]
+  public async Task CreateRegistryProxyAsync_RegistryDoesNotExist_CreatesRegistry()
+  {
+    //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
+    if ((RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
+    {
+      return;
+    }
+
+    // Arrange
+    string registryName = "new_registry";
+    int port = 5999;
+    var cancellationToken = CancellationToken.None;
+
+    // Act
+    await _provisioner.CreateRegistryProxyAsync(registryName, port, new ReadOnlyCollection<Uri>([new("https://registry-1.docker.io"), new("https://ghcr.io")]), cancellationToken: cancellationToken);
+
+    // Assert
+    bool registryExists = await _provisioner.CheckContainerExistsAsync(registryName, cancellationToken: cancellationToken);
+    Assert.True(registryExists);
+
+    // Cleanup
+    await _provisioner.DeleteRegistryAsync(registryName, cancellationToken: cancellationToken);
+  }
+
+  /// <summary>
+  /// Tests whether the registry is not created when it already exists.
+  /// </summary>
+  [Fact]
+  public async Task CreateRegistryProxyAsync_RegistryExists_DoesNotCreateRegistry()
+  {
+    //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    {
+      return;
+    }
+
+    // Arrange
+    string registryName = "new_registry";
+    int port = 5999;
+    var cancellationToken = CancellationToken.None;
+
+    // Act
+    await _provisioner.CreateRegistryProxyAsync(registryName, port, new ReadOnlyCollection<Uri>([new("https://registry-1.docker.io"), new("https://ghcr.io")]), cancellationToken: cancellationToken);
+    await _provisioner.CreateRegistryProxyAsync(registryName, port, new ReadOnlyCollection<Uri>([new("https://registry-1.docker.io"), new("https://ghcr.io")]), cancellationToken: cancellationToken);
+
+    // Assert
+    bool registry1Exists = await _provisioner.CheckContainerExistsAsync(registryName, cancellationToken);
+    await _provisioner.DeleteRegistryAsync(registryName, cancellationToken);
+    Assert.True(registry1Exists);
+    bool registry2Exists = await _provisioner.CheckContainerExistsAsync(registryName, cancellationToken);
+    Assert.False(registry2Exists);
+  }
+}

--- a/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryProxyAsyncTests.cs
+++ b/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryProxyAsyncTests.cs
@@ -24,8 +24,8 @@ public class CreateRegistryProxyAsyncTests
     }
 
     // Arrange
-    string registryName = "new_registry";
-    int port = 5999;
+    string registryName = "docker-registry-proxy";
+    int port = 6999;
     var cancellationToken = CancellationToken.None;
 
     // Act
@@ -52,8 +52,8 @@ public class CreateRegistryProxyAsyncTests
     }
 
     // Arrange
-    string registryName = "new_registry";
-    int port = 5999;
+    string registryName = "docker-registry-proxy";
+    int port = 6999;
     var cancellationToken = CancellationToken.None;
 
     // Act

--- a/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryProxyAsyncTests.cs
+++ b/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryProxyAsyncTests.cs
@@ -46,7 +46,7 @@ public class CreateRegistryProxyAsyncTests
   public async Task CreateRegistryProxyAsync_RegistryExists_DoesNotCreateRegistry()
   {
     //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    if ((RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
     {
       return;
     }


### PR DESCRIPTION
Introduce CreateRegistryProxyAsync method to enable the creation of a 'rpardini/docker-registry-proxy' in the container engine. Include unit tests to verify functionality for both creating a new registry and handling existing ones.