### PR TITLE
feat: add methods to connect containers to networks by name and ID

### DIFF
--- a/src/Devantler.ContainerEngineProvisioner.Core/IContainerEngineProvisioner.cs
+++ b/src/Devantler.ContainerEngineProvisioner.Core/IContainerEngineProvisioner.cs
@@ -59,4 +59,18 @@ public interface IContainerEngineProvisioner
   /// Create a file in a container.
   /// </summary>
   Task CreateFileInContainerAsync(string containerId, string path, string content, CancellationToken cancellationToken = default);
+
+  /// <summary>
+  /// Connects a container to a network by name.
+  /// </summary>
+  Task ConnectContainerToNetworkByNameAsync(string containerName, string networkName, CancellationToken cancellationToken = default);
+
+  /// <summary>
+  /// Connects a container to a network by ID.
+  /// </summary>
+  /// <param name="containerId"></param>
+  /// <param name="networkId"></param>
+  /// <param name="cancellationToken"></param>
+  /// <returns></returns>
+  Task ConnectContainerToNetworkByIdAsync(string containerId, string networkId, CancellationToken cancellationToken = default);
 }

--- a/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/Devantler.ContainerEngineProvisioner.Docker.Tests.csproj
+++ b/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/Devantler.ContainerEngineProvisioner.Docker.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 

--- a/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/ConnectContainerToNetworkByIdAsyncTests.cs
+++ b/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/ConnectContainerToNetworkByIdAsyncTests.cs
@@ -1,0 +1,68 @@
+using Docker.DotNet.Models;
+
+namespace Devantler.ContainerEngineProvisioner.Docker.Tests.DockerProvisionerTests;
+
+/// <summary>
+/// Unit tests for <see cref="DockerProvisioner.ConnectContainerToNetworkByIdAsync(string, string, CancellationToken)"/>.
+/// </summary>
+public class ConnectContainerToNetworkByIdAsyncTests
+{
+  readonly DockerProvisioner _dockerProvisioner = new();
+
+  /// <summary>
+  /// Tests the <see cref="DockerProvisioner.ConnectContainerToNetworkByIdAsync(string, string, CancellationToken)"/> method.
+  /// </summary>
+  /// <returns></returns>
+  [SkippableFact]
+  public async Task ConnectContainerToNetworkByIdAsync_WhenCalled_ConnectsContainerToNetwork()
+  {
+    //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
+    Skip.If(
+      (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true",
+      "Skipping test on Windows and MacOS in GitHub Actions."
+    );
+
+    // Arrange
+    string containerName = "connect_container_to_network_by_id_test";
+    string networkName = "test_network_by_id";
+    await _dockerProvisioner.Client.Images.CreateImageAsync(
+      new ImagesCreateParameters
+      {
+        FromImage = "alpine",
+        Tag = "latest",
+      },
+      null,
+      new Progress<JSONMessage>()).ConfigureAwait(false);
+    var createContainerResponse = await _dockerProvisioner.Client.Containers.CreateContainerAsync(new CreateContainerParameters
+    {
+      Image = "alpine:latest",
+      Cmd = ["sleep", "inf"],
+      Name = containerName
+    }).ConfigureAwait(false);
+    _ = await _dockerProvisioner.Client.Containers.StartContainerAsync(
+      createContainerResponse.ID,
+      new ContainerStartParameters()
+    ).ConfigureAwait(false);
+    var createNetworkResponse = await _dockerProvisioner.Client.Networks.CreateNetworkAsync(new NetworksCreateParameters
+    {
+      Name = networkName,
+      Driver = "bridge"
+    }).ConfigureAwait(false);
+
+    // Act
+    await _dockerProvisioner.ConnectContainerToNetworkByIdAsync(createContainerResponse.ID, createNetworkResponse.ID).ConfigureAwait(false);
+
+    // Assert
+    var network = await _dockerProvisioner.Client.Networks.InspectNetworkAsync(createNetworkResponse.ID).ConfigureAwait(false);
+    var container = network.Containers.FirstOrDefault(c => c.Key == createContainerResponse.ID);
+    Assert.NotNull(network);
+    Assert.Equal(networkName, network.Name);
+    Assert.Equal(createNetworkResponse.ID, network.ID);
+    Assert.Equal(containerName, container.Value.Name);
+
+    // Cleanup
+    _ = await _dockerProvisioner.Client.Containers.StopContainerAsync(createContainerResponse.ID, new ContainerStopParameters()).ConfigureAwait(false);
+    await _dockerProvisioner.Client.Containers.RemoveContainerAsync(createContainerResponse.ID, new ContainerRemoveParameters()).ConfigureAwait(false);
+    await _dockerProvisioner.Client.Networks.DeleteNetworkAsync(createNetworkResponse.ID).ConfigureAwait(false);
+  }
+}

--- a/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/ConnectContainerToNetworkByNameAsyncTests.cs
+++ b/tests/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/ConnectContainerToNetworkByNameAsyncTests.cs
@@ -1,0 +1,68 @@
+using Docker.DotNet.Models;
+
+namespace Devantler.ContainerEngineProvisioner.Docker.Tests.DockerProvisionerTests;
+
+/// <summary>
+/// Unit tests for <see cref="DockerProvisioner.ConnectContainerToNetworkByNameAsync(string, string, CancellationToken)"/>.
+/// </summary>
+public class ConnectContainerToNetworkByNameAsyncTests
+{
+  readonly DockerProvisioner _dockerProvisioner = new();
+
+  /// <summary>
+  /// Tests the <see cref="DockerProvisioner.ConnectContainerToNetworkByNameAsync(string, string, CancellationToken)"/> method.
+  /// </summary>
+  /// <returns></returns>
+  [SkippableFact]
+  public async Task ConnectContainerToNetworkByNameAsync_WhenCalled_ConnectsContainerToNetwork()
+  {
+    //TODO: Support MacOS and Windows when GitHub Actions runners supports dind.
+    Skip.If(
+      (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true",
+      "Skipping test on Windows and MacOS in GitHub Actions."
+    );
+
+    // Arrange
+    string containerName = "connect_container_to_network_by_name_test";
+    string networkName = "test_network_by_name";
+    await _dockerProvisioner.Client.Images.CreateImageAsync(
+      new ImagesCreateParameters
+      {
+        FromImage = "alpine",
+        Tag = "latest",
+      },
+      null,
+      new Progress<JSONMessage>()).ConfigureAwait(false);
+    var createContainerResponse = await _dockerProvisioner.Client.Containers.CreateContainerAsync(new CreateContainerParameters
+    {
+      Image = "alpine:latest",
+      Cmd = ["sleep", "inf"],
+      Name = containerName
+    }).ConfigureAwait(false);
+    _ = await _dockerProvisioner.Client.Containers.StartContainerAsync(
+      createContainerResponse.ID,
+      new ContainerStartParameters()
+    ).ConfigureAwait(false);
+    var createNetworkResponse = await _dockerProvisioner.Client.Networks.CreateNetworkAsync(new NetworksCreateParameters
+    {
+      Name = networkName,
+      Driver = "bridge"
+    }).ConfigureAwait(false);
+
+    // Act
+    await _dockerProvisioner.ConnectContainerToNetworkByNameAsync(containerName, networkName).ConfigureAwait(false);
+
+    // Assert
+    var network = await _dockerProvisioner.Client.Networks.InspectNetworkAsync(createNetworkResponse.ID).ConfigureAwait(false);
+    var container = network.Containers.FirstOrDefault(c => c.Value.Name == containerName);
+    Assert.NotNull(network);
+    Assert.Equal(networkName, network.Name);
+    Assert.Equal(createNetworkResponse.ID, network.ID);
+    Assert.Equal(containerName, container.Value.Name);
+
+    // Cleanup
+    _ = await _dockerProvisioner.Client.Containers.StopContainerAsync(createContainerResponse.ID, new ContainerStopParameters()).ConfigureAwait(false);
+    await _dockerProvisioner.Client.Containers.RemoveContainerAsync(createContainerResponse.ID, new ContainerRemoveParameters()).ConfigureAwait(false);
+    await _dockerProvisioner.Client.Networks.DeleteNetworkAsync(createNetworkResponse.ID).ConfigureAwait(false);
+  }
+}


### PR DESCRIPTION
Introduce methods for connecting containers to networks using either their names or IDs, along with corresponding unit tests to ensure functionality.