### PR TITLE
feat: enhance DockerProvisioner to support Podman socket and remove GlobalSuppressions.cs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -52,6 +52,7 @@ dotnet_naming_style.constant_style.capitalization = pascal_case
 
 # Disable rules
 dotnet_diagnostic.CA1014.severity = none
+dotnet_diagnostic.CA1303.severity = none
 
 [*.{received,verified}.*]
 generated_code = true

--- a/src/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
+++ b/src/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Runtime.InteropServices;
 using Devantler.ContainerEngineProvisioner.Core;
 using Docker.DotNet;
 using Docker.DotNet.Models;
@@ -20,16 +21,15 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
   /// </summary>
   public DockerProvisioner()
   {
-    string? dockerHost = Environment.GetEnvironmentVariable("DOCKER_HOST");
-    if (!string.IsNullOrEmpty(dockerHost))
-    {
-      var uri = new Uri(dockerHost);
-      using var uriConfig = new DockerClientConfiguration(uri);
-      Client = uriConfig.CreateClient();
-      return;
-    }
-    using var defaultConfig = new DockerClientConfiguration();
-    Client = defaultConfig.CreateClient();
+    string dockerHost = Environment.GetEnvironmentVariable("DOCKER_HOST") ?? "unix:/var/run/docker.sock";
+    string podmanSocket = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && File.Exists(@"\\.\pipe\docker_engine") ?
+      "npipe://./pipe/docker_engine" : File.Exists($"/run/podman/podman.sock") ?
+      $"unix:/run/podman/podman.sock" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock") ?
+      $"unix:/run/user/{Environment.GetEnvironmentVariable("EUID")}/podman/podman.sock" : File.Exists($"/run/user/{Environment.GetEnvironmentVariable("UID")}/podman/podman.sock") ?
+      $"unix:/run/user/{Environment.GetEnvironmentVariable("UID")}/podman/podman.sock" : dockerHost;
+
+    using var uriConfig = new DockerClientConfiguration(new Uri(podmanSocket));
+    Client = uriConfig.CreateClient();
   }
 
   /// <inheritdoc/>
@@ -82,6 +82,9 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
         recursive ? "-p" : "",
         path
       ],
+      AttachStdin = true,
+      AttachStdout = true,
+      AttachStderr = true
     }, cancellationToken).ConfigureAwait(false);
     _ = await Client.Exec.StartAndAttachContainerExecAsync(execResponse.ID, true, cancellationToken).ConfigureAwait(false);
     await Task.Delay(100, cancellationToken).ConfigureAwait(false);
@@ -105,7 +108,10 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
         "sh",
         "-c",
         $"echo '{content}' > {path}"
-      ]
+      ],
+      AttachStdin = true,
+      AttachStdout = true,
+      AttachStderr = true
     }, cancellationToken).ConfigureAwait(false);
     _ = await Client.Exec.StartAndAttachContainerExecAsync(execResponse.ID, true, cancellationToken).ConfigureAwait(false);
   }

--- a/src/Devantler.ContainerEngineProvisioner.Docker/GlobalSuppressions.cs
+++ b/src/Devantler.ContainerEngineProvisioner.Docker/GlobalSuppressions.cs
@@ -1,6 +1,0 @@
-// This file is used by Code Analysis to maintain SuppressMessage attributes that are applied to this project.
-// Project-level suppressions either have no target or are given a specific target and scoped to a namespace, type, member, etc.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Global suppression for CA1303")]


### PR DESCRIPTION
Enhance the DockerProvisioner to support connecting to a Podman socket in addition to Docker. Remove the GlobalSuppressions.cs file as it is no longer needed.